### PR TITLE
feat: allow missing ssm params

### DIFF
--- a/tools/lambda-promtail/lambda-promtail/ssm_parameters.go
+++ b/tools/lambda-promtail/lambda-promtail/ssm_parameters.go
@@ -112,8 +112,6 @@ func getEnvironmentVariables(varNames []string) (variables map[string]string) {
 			variables[varName] = value
 			continue
 		}
-
-		panic(fmt.Sprintf("%s is not preset", varName))
 	}
 
 	return


### PR DESCRIPTION
Allows missing ssm parameters, not specified in env vars